### PR TITLE
optionally invert agent-env relation

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,9 @@
+use crate::{env::Environment, memory::Exp};
+
+pub trait Agent<E>
+where
+    E: Environment,
+{
+    fn act(&self, state: &E::State, actions: &[E::Action]) -> E::Action;
+    fn learn(&mut self, exp: Exp<E>, next_actions: &[E::Action]);
+}

--- a/src/algo/tabular/ucb.rs
+++ b/src/algo/tabular/ucb.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
+    agent::Agent,
     env::{DiscreteActionSpace, Environment},
     memory::Exp,
 };
@@ -151,5 +152,19 @@ where
         }
 
         self.episode += 1;
+    }
+}
+impl<E> Agent<E> for UCBAgent<E>
+where
+    E: Environment + DiscreteActionSpace,
+    E::State: Hashable,
+    E::Action: Hashable + From<usize>,
+{
+    fn act(&self, state: &E::State, actions: &[E::Action]) -> E::Action {
+        self.act(*state, actions)
+    }
+
+    fn learn(&mut self, exp: Exp<E>, _: &[E::Action]) {
+        self.learn(exp);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod ds;
 /// Environment
 pub mod env;
 
+pub mod agent;
+
 /// Exploration policies
 pub mod exploration;
 


### PR DESCRIPTION
Found this repo to be quite intuitive to use, thanks for making it open source! From the usage perspective, I felt that it would be good to have a stricter Agent trait that is invoked from an Env - which maybe fairly complicated in itself. Please let me know if you have concerns!